### PR TITLE
Fix ItemQueue/BlockingItemQueue tests

### DIFF
--- a/zipkin-collector/src/test/scala/com/twitter/zipkin/collector/BlockingItemQueueTest.scala
+++ b/zipkin-collector/src/test/scala/com/twitter/zipkin/collector/BlockingItemQueueTest.scala
@@ -2,16 +2,15 @@ package com.twitter.zipkin.collector
 
 import com.twitter.conversions.time._
 import com.twitter.finagle.stats.InMemoryStatsReceiver
-import com.twitter.util.{Await, Future}
+import com.twitter.util.{Await, Future, FuturePool}
+import java.util.concurrent.CountDownLatch
+import scala.util.Try
 import org.scalatest._
 
-/**
- * Tests the BlockingItemQueue to make sure that it can store and consume elements even when adding
- * more elements than what its initial capacity is
- */
 class BlockingItemQueueTest extends FunSuite {
 
   val Item = ()
+  val latch = new CountDownLatch(1)
 
   def fill(queue: BlockingItemQueue[Unit, Unit], items: Int): Future[Boolean] = {
     val results = (0 until items) map { _ =>
@@ -21,23 +20,43 @@ class BlockingItemQueueTest extends FunSuite {
   }
 
   test("Sleeps on a max queue and waits for the worker to drain") {
-
+    val expectedItemCount = 12
+    val queueSize = 10
     val stats:InMemoryStatsReceiver = new InMemoryStatsReceiver()
-    val queue = new BlockingItemQueue[Unit, Unit](10, 1, fallingBehindWorker, 100.millis,
-                                                  100.millis, stats)
+    val queue = new BlockingItemQueue[Unit, Unit](queueSize, 1, fallingBehindWorker, 100.millis, 100.millis, stats)
+
+
     // Add 11 and not 10 because the first one that's going to be added will be consumed right away
-    assert(Await.result(fill(queue, 11)))
-    assert(Await.ready(queue.add(Item)).poll.get.isReturn)
+    assert(Await.result(fill(queue, queueSize + 1)))
+
+    // add an item, expect the queueFull stat to get incremented we need this to return because
+    // the blocking queue will block because its full, so we use a future
+    FuturePool.unboundedPool { queue.add(Item) }
+    // poll for when the queueFull counter gets incremented or timeout
+    poll( () => stats.counter("queueFull").apply() >= 1 )
+    // Items are sitting in the queue blocking and not processing, this unblocks them
+    latch.countDown()
+
+    // Wait for all items to be processed
+    poll( () => queue.size() == 0 )
     Await.ready(queue.close())
-    assert(stats.counter("queueFull").apply() >= 1)
-    assert(stats.counter("successes").apply() == 12)
+
+    // All items should be processed
+    poll( () => stats.counter("successes").apply() == expectedItemCount )
     assert(queue.size() == 0)
+    assert(stats.counter("queueFull").apply() >= 1)
+  }
+
+  def poll(f: () => Boolean): Boolean = {
+    for (a <- 1 to 5) {
+      if (f()) return true else Thread.sleep(1000)
+    }
+    false
   }
 
   def fallingBehindWorker(param: Unit): Future[Unit] = {
-    Future { Thread.sleep(100)
-              param
-           }
+    //block instead of sleeping
+    Future { latch.await(); param }
   }
 
 }

--- a/zipkin-collector/src/test/scala/com/twitter/zipkin/collector/ItemQueueTest.scala
+++ b/zipkin-collector/src/test/scala/com/twitter/zipkin/collector/ItemQueueTest.scala
@@ -39,7 +39,7 @@ class ItemQueueTest extends FunSuite {
     })
 
     assert(Await.result(fill(queue, 5)))
-    assert(processed.await(500, TimeUnit.MILLISECONDS))
+    assert(processed.await(5, TimeUnit.SECONDS))
   }
 
   test("runs a specified number of concurrent workers") {
@@ -62,7 +62,7 @@ class ItemQueueTest extends FunSuite {
 
     // complete processing
     latch.countDown()
-    assert(processed.await(100, TimeUnit.MILLISECONDS))
+    assert(processed.await(5, TimeUnit.SECONDS))
   }
 
   test("enforces a max queue size") {

--- a/zipkin-collector/src/test/scala/com/twitter/zipkin/collector/ItemQueueTest.scala
+++ b/zipkin-collector/src/test/scala/com/twitter/zipkin/collector/ItemQueueTest.scala
@@ -94,6 +94,7 @@ class ItemQueueTest extends FunSuite {
     assert(Await.ready(queue.add(Item)).poll.get.isThrow)
 
     latch.countDown()
-    assert(processed.await(100, TimeUnit.MILLISECONDS))
+    assert(processed.await(5, TimeUnit.SECONDS))
+
   }
 }


### PR DESCRIPTION
### Problem
Have been seeing intermittent build failures in travis, this is a stab at fixing these errors. 

### Solution
ItemQueueTest
* adding a sleep in the Items causes the error to be manifested, it shows the items aren't getting drained out of the queue.  The theory is that in travis sometimes the latch takes longer than 100ms to close.  Thus increasing timeout to 5s, which should cover most cases.

BlockingItemQueueTest
* If you add a sleep after the initial fill(), then test adding an overflow item, you see that the test fails.  I believe the queue sometimes drains too fast, thus we never overflow.  Switching to use a countdown latch which sync's all the items to exit at the same-ish time.  Similar to ItemeQueueTest's usage.